### PR TITLE
Fix paths with markers but no path segments

### DIFF
--- a/source.js
+++ b/source.js
@@ -1856,7 +1856,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
               markerEnd = this.get('marker-end');
           if (markerStart !== 'none' || markerMid !== 'none' || markerEnd !== 'none') {
             let markersPos = this.shape.getMarkers();
-            if (markerStart !== 'none') {
+            if (markerStart !== 'none' && markersPos.length > 0) {
               let marker = new SvgElemMarker(markerStart, null);
               marker.drawMarker(false, isMask, markersPos[0], lineWidth);
             }
@@ -1866,7 +1866,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
                 marker.drawMarker(false, isMask, markersPos[i], lineWidth);
               }
             }
-            if (markerEnd !== 'none') {
+            if (markerEnd !== 'none' && markersPos.length > 0) {
               let marker = new SvgElemMarker(markerEnd, null);
               marker.drawMarker(false, isMask, markersPos[markersPos.length - 1], lineWidth);
             }


### PR DESCRIPTION
`<path d="" marker-start="url(#marker)" marker-end="url(#marker)"></path>` is valid, but svg-to-pdfkit was throwing an error when encountering it because it was assuming a path with a marker-start or marker-end would always have at least one path segment. So remove that assumption.